### PR TITLE
 Původní level z Tracy log

### DIFF
--- a/src/DI/Extension.php
+++ b/src/DI/Extension.php
@@ -42,7 +42,7 @@ final class Extension extends \Nette\DI\CompilerExtension
 	{
 		$initialize = $class->getMethod('initialize');
 
-		$initialize->addBody('$tracyLogger = new \Tracy\Bridges\Psr\PsrToTracyLoggerAdapter($this->getByType(\Psr\Log\LoggerInterface::class));');
+		$initialize->addBody('$tracyLogger = new \Pd\MonologModule\Tracy\PsrToTracyLoggerAdapter($this->getByType(\Psr\Log\LoggerInterface::class));');
 		$initialize->addBody('\Tracy\Debugger::setLogger($tracyLogger);');
 	}
 

--- a/src/Tracy/PsrToTracyLoggerAdapter.php
+++ b/src/Tracy/PsrToTracyLoggerAdapter.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types = 1);
+
+namespace Pd\MonologModule\Tracy;
+
+class PsrToTracyLoggerAdapter implements \Tracy\ILogger
+{
+	/** Tracy logger level to PSR-3 log level mapping */
+	private const LEVEL_MAP = [
+		\Tracy\ILogger::DEBUG => \Psr\Log\LogLevel::DEBUG,
+		\Tracy\ILogger::INFO => \Psr\Log\LogLevel::INFO,
+		\Tracy\ILogger::WARNING => \Psr\Log\LogLevel::WARNING,
+		\Tracy\ILogger::ERROR => \Psr\Log\LogLevel::ERROR,
+		\Tracy\ILogger::EXCEPTION => \Psr\Log\LogLevel::ERROR,
+		\Tracy\ILogger::CRITICAL => \Psr\Log\LogLevel::CRITICAL,
+	];
+
+	/** @var \Psr\Log\LoggerInterface */
+	private $psrLogger;
+
+
+	public function __construct(\Psr\Log\LoggerInterface $psrLogger)
+	{
+		$this->psrLogger = $psrLogger;
+	}
+
+
+	public function log($value, $level = self::INFO)
+	{
+		if ($value instanceof \Throwable) {
+			$message = \Tracy\Helpers::getClass($value) . ': ' . $value->getMessage() . ($value->getCode() ? ' #' . $value->getCode() : '') . ' in ' . $value->getFile() . ':' . $value->getLine();
+			$context = ['exception' => $value];
+
+		} elseif ( ! \is_string($value)) {
+			$message = \trim(\Tracy\Dumper::toText($value));
+			$context = [];
+
+		} else {
+			$message = $value;
+			$context = [];
+		}
+
+		if ( ! isset(self::LEVEL_MAP[$level])) {
+			$context['originalLevel'] = $level;
+
+			$level = \Tracy\ILogger::INFO;
+		}
+
+		$this->psrLogger->log(
+			self::LEVEL_MAP[$level],
+			$message,
+			$context
+		);
+	}
+
+}


### PR DESCRIPTION
 - Jakmile dojde k zalogování pomocí Tracy log tak v případně chybně
 zadaného levelu došlo k jeho zahození a zpráva se označila jako error.

 - Požadavek byl tedy takový aby se do kontextu dostala i původní hodnota.
 - Zároveň zprávu označujeme nově jako INFO aby nedocházelo k nechtěnému
 probublání zpráv do Sentry, NewRelic atd.