### PR TITLE
Doplnění interface k pro processorům

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,10 @@
 		"psr-4": {
 			"PdTests\\MonologModule\\": "tests"
 		}
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/src/Processors/BlueScreenProcessor.php
+++ b/src/Processors/BlueScreenProcessor.php
@@ -2,7 +2,7 @@
 
 namespace Pd\MonologModule\Processors;
 
-final class BlueScreenProcessor
+final class BlueScreenProcessor implements \Monolog\Processor\ProcessorInterface
 {
 
 	private \Tracy\BlueScreen $blueScreenRenderer;

--- a/src/Processors/ContextChannelProcessor.php
+++ b/src/Processors/ContextChannelProcessor.php
@@ -2,7 +2,7 @@
 
 namespace Pd\MonologModule\Processors;
 
-final class ContextChannelProcessor
+final class ContextChannelProcessor implements \Monolog\Processor\ProcessorInterface
 {
 
 	/**


### PR DESCRIPTION
- všechny processory pro monolog musí a implementují interface na projektech následně toho využíváme při autowiringu